### PR TITLE
Corrige o tratamento de caminhos não confiáveis e endurece o workflow

### DIFF
--- a/.github/workflows/hf-model-to-ghcr.yml
+++ b/.github/workflows/hf-model-to-ghcr.yml
@@ -165,7 +165,9 @@ jobs:
           name: plan
 
       - name: Preparar área de trabalho em disco
+        shell: bash
         run: |
+          set -euo pipefail
           # O disco raiz do runner tem ~20 GB livres; /mnt tem ~65 GB. Um GGUF
           # precisa caber duas vezes: o arquivo baixado e a cópia que o
           # `ollama create` grava no diretório de blobs.
@@ -173,15 +175,21 @@ jobs:
           sudo chown -R "$(id -u):$(id -g)" /mnt/hf /mnt/ollama /mnt/build
           df -h / /mnt
 
-          # O `ollama create` grava uma segunda cópia dos pesos no diretório de
-          # blobs, então o modelo precisa caber duas vezes.
           need_bytes=$(python3 -c "
           import json
           plan = json.load(open('plan.json'))
           size = plan['gguf_bytes'] or plan['snapshot_bytes']
           print(max(int(size * 2.2), 2 * 1024**3))
           ")
+          # Sem pipefail um `df` que falha vira string vazia, que a aritmética do
+          # bash lê como zero — e a comparação passaria a mentir. Daí o
+          # `set -o pipefail` acima e a validação explícita abaixo.
           free_bytes=$(df -B1 --output=avail /mnt | tail -1 | tr -dc '0-9')
+          if [[ ! "$free_bytes" =~ ^[0-9]+$ || ! "$need_bytes" =~ ^[0-9]+$ ]]; then
+            echo "❌ não foi possível medir o espaço em /mnt (livre='${free_bytes}', necessário='${need_bytes}')."
+            exit 1
+          fi
+          echo "espaço livre em /mnt: $((free_bytes/1024**3)) GiB | necessário: $((need_bytes/1024**3)) GiB"
           if (( free_bytes < need_bytes )); then
             echo "❌ /mnt tem $((free_bytes/1024**3)) GiB livres, o modelo precisa de ~$((need_bytes/1024**3)) GiB."
             echo "   Escolha uma quantização menor com o input file_pattern."
@@ -222,12 +230,30 @@ jobs:
           PY
           echo "--- Modelfile ---"; cat /mnt/build/Modelfile; echo "-----------------"
 
-          ollama serve &
+          # Sem guardar o log e o PID, um `ollama serve` que morre na largada
+          # (porta ocupada, instalação quebrada) só apareceria como 60 s de
+          # espera e um curl mudo.
+          ollama serve > /mnt/build/ollama-serve.log 2>&1 &
+          serve_pid=$!
+          ready=false
           for _ in $(seq 1 60); do
-            curl -sf http://127.0.0.1:11434/api/version >/dev/null && break
+            if ! kill -0 "$serve_pid" 2>/dev/null; then
+              echo '❌ o servidor do Ollama encerrou durante a inicialização:'
+              cat /mnt/build/ollama-serve.log
+              exit 1
+            fi
+            if curl -sf http://127.0.0.1:11434/api/version >/dev/null; then
+              ready=true
+              break
+            fi
             sleep 1
           done
-          curl -sf http://127.0.0.1:11434/api/version
+          if [[ "$ready" != "true" ]]; then
+            echo "❌ o servidor do Ollama não respondeu em 60 s:"
+            cat /mnt/build/ollama-serve.log
+            exit 1
+          fi
+          curl -sf http://127.0.0.1:11434/api/version; echo
 
           ollama create '${{ needs.plan.outputs.image }}' -f /mnt/build/Modelfile
           ollama list
@@ -296,20 +322,34 @@ jobs:
       - name: Publicar como artefato OCI
         run: |
           set -euo pipefail
-          oras login ghcr.io --username "$GHCR_USERNAME" --password-stdin <<< "$GHCR_TOKEN"
+          # `printf` é builtin e o token vai por um pipe: ele não aparece na
+          # linha de comando de nenhum processo. Uma here-string (<<<) seria
+          # equivalente do ponto de vista do argv, mas o bash a materializa num
+          # arquivo temporário — o pipe evita até isso.
+          printf '%s' "$GHCR_TOKEN" | oras login ghcr.io \
+            --username "$GHCR_USERNAME" --password-stdin
 
           # Cada arquivo vira uma camada própria, com o caminho relativo no
           # annotation de título. Assim o `oras pull` reconstrói o diretório no
           # layout que MLX, transformers, LM Studio e llama.cpp esperam — e um
           # arquivo corrompido não obriga a rebaixar o modelo inteiro.
-          mapfile -t FILES < <(python3 - <<'PY'
+          # Delimitado por NUL: um caminho com quebra de linha viraria duas
+          # entradas do array e desalinharia a lista de argumentos. Os caminhos
+          # já foram validados no job `plan`, isto é a segunda barreira.
+          mapfile -d '' -t FILES < <(python3 - <<'PY'
           import json
+          import sys
+
           plan = json.load(open("plan.json"))
           for path in plan["snapshot_files"]:
-              print(f"{path}:application/octet-stream")
+              sys.stdout.write(f"{path}:application/octet-stream\0")
           PY
           )
           echo "📦 ${#FILES[@]} arquivos"
+          if (( ${#FILES[@]} == 0 )); then
+            echo "❌ o plano não lista nenhum arquivo para publicar."
+            exit 1
+          fi
 
           cd /mnt/hf
           rm -rf .cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+    paths: ['scripts/**', 'tests/**', '.github/workflows/**']
+  pull_request:
+    paths: ['scripts/**', 'tests/**', '.github/workflows/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Compilar os scripts
+        run: python3 -m compileall -q scripts tests
+
+      - name: Checar a sintaxe dos scripts de shell
+        run: |
+          set -euo pipefail
+          bash -n scripts/pull-model.sh
+          # Os blocos `run:` dos workflows também são shell: um erro de sintaxe
+          # ali só apareceria no meio de uma publicação de 40 GB.
+          python3 - <<'PY'
+          import glob
+          import re
+          import subprocess
+          import sys
+          import tempfile
+
+          import yaml
+
+          falhas = []
+          for arquivo in sorted(glob.glob(".github/workflows/*.y*ml")):
+              doc = yaml.safe_load(open(arquivo, encoding="utf-8"))
+              for nome_job, job in (doc.get("jobs") or {}).items():
+                  for passo in job.get("steps") or []:
+                      script = passo.get("run")
+                      if not script:
+                          continue
+                      # As expressões ${{ }} são resolvidas antes do shell rodar.
+                      script = re.sub(r"\$\{\{[^}]*\}\}", "PLACEHOLDER", script)
+                      with tempfile.NamedTemporaryFile("w", suffix=".sh") as fh:
+                          fh.write(script)
+                          fh.flush()
+                          r = subprocess.run(["bash", "-n", fh.name], capture_output=True, text=True)
+                      alvo = f"{arquivo} :: {nome_job} :: {passo.get('name', '(sem nome)')}"
+                      if r.returncode:
+                          falhas.append(f"{alvo}\n{r.stderr.strip()}")
+                      else:
+                          print(f"ok {alvo}")
+          if falhas:
+              print("\n".join(falhas), file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Testes de caminho e de vazamento de descritores
+        run: python3 tests/test_paths.py

--- a/README.md
+++ b/README.md
@@ -8,201 +8,90 @@ Cada modelo é publicado em duas referências:
 | Referência | Formato | Quem consome |
 |---|---|---|
 | `ghcr.io/<owner>/<pacote>:<tag>` | manifesto nativo do Ollama | `ollama pull` |
-| `ghcr.io/<owner>/<pacote>:<tag>-hf` | artefato OCI com o layout do Hugging Face | LM Studio, MLX, llama.cpp, `transformers`, e qualquer agente que carregue um diretório local (OpenClaw, Pi, Hermes Agent…) |
+| `ghcr.io/<owner>/<pacote>:<tag>-hf` | artefato OCI com o layout do Hugging Face | LM Studio, MLX, llama.cpp, `transformers`, vLLM, e agentes que carregam um diretório local |
+
+## 📚 [Documentação completa →](docs/)
+
+| Guia | Assunto |
+|---|---|
+| [1. Publicar um modelo](docs/01-publicar.md) | os dois workflows, todos os inputs, o que acontece em cada job |
+| [2. Deixar o pacote público](docs/02-visibilidade.md) | **leia antes da primeira execução** — a escolha é irreversível |
+| [3. Usar nos clientes](docs/03-clientes.md) | Ollama, LM Studio, MLX, llama.cpp, transformers, agentes |
+| [4. Escolher o modelo certo](docs/04-escolher-modelo.md) | qual repo do HF espelhar, quantização, o que cabe na sua RAM |
+| [5. Erros comuns](docs/05-erros-comuns.md) | diagnóstico por sintoma |
 
 ---
 
-## Qual cliente funciona com qual modelo
+## Começando
 
-O espelhamento é fiel: ele copia o formato que existe no Hugging Face, sem
-converter nada. Então a compatibilidade é a do **modelo de origem**, não do
-GHCR. A regra que mais pega gente de surpresa:
+**1. Publique** — *Actions → Sync HF Model to GHCR → Run workflow*:
 
-> **MLX não lê GGUF.** O `mlx-lm` faz `glob("model*.safetensors")` e aborta com
-> `No safetensors found` se não achar. Espelhar um repo `*-GGUF` e esperar usar
-> no MLX não vai funcionar — nem aqui, nem baixando direto do Hugging Face.
+```
+model_repo   = bartowski/Qwen2.5-7B-Instruct-GGUF
+package_name = models
+```
+
+**2. Torne o pacote público, uma vez** — perfil → aba **Packages** → `models` →
+**Package settings** → **Danger Zone** → **Change visibility** → **Public**.
+
+Isso é obrigatório: o `ollama pull` só usa token anônimo em registros de
+terceiros. A visibilidade do pacote **não** é herdada do repositório, e não
+existe API para mudá-la. Detalhes e a estratégia para fazer isso uma única vez
+na vida estão no [guia 2](docs/02-visibilidade.md).
+
+**3. Use:**
+
+```bash
+ollama pull ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+
+# outros clientes
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m-hf --for lmstudio
+```
+
+---
+
+## Compatibilidade, em uma tabela
+
+O espelhamento copia fielmente o formato de origem — ele não converte nada.
+Então quem decide a compatibilidade é o repositório que você escolhe no Hugging
+Face:
 
 | Origem no HF | Ollama | llama.cpp | LM Studio | MLX | transformers |
 |---|:--:|:--:|:--:|:--:|:--:|
 | `*-GGUF` (bartowski, unsloth…) | ✅ | ✅ | ✅ | ❌ | ❌ |
-| `mlx-community/*` (MLX quantizado) | ⚠️ | ❌ | ✅ | ✅ | ✅ |
+| `mlx-community/*` | ⚠️ | ❌ | ✅ | ✅ | ✅ |
 | safetensors fp16/bf16 | ⚠️ | ❌ | ❌ | ✅ | ✅ |
 | AWQ / GPTQ / MXFP4 | ⚠️ | ❌ | ❌ | ✅ | ✅ |
 | bitsandbytes 4/8-bit | ⚠️ | ❌ | ❌ | ❌ | ✅ |
 
-⚠️ = o Ollama importa safetensors, mas só nas arquiteturas que ele já
-implementa. O workflow tenta e falha alto se não der.
+**MLX não lê GGUF** — para cobrir Apple Silicon inteiro, espelhe dois repos: um
+`*-GGUF` e o `mlx-community/*` correspondente. O job `plan` publica essa tabela
+já resolvida para o seu modelo no resumo de cada execução.
 
-**Se você quer cobrir Apple Silicon inteiro, espelhe dois repos:** um `*-GGUF`
-(Ollama, LM Studio, llama.cpp) e o `mlx-community/*` correspondente (MLX). São
-dois modelos diferentes no HF, então são duas execuções do workflow.
-
-O job `plan` publica essa tabela no resumo de cada execução, já resolvida para o
-modelo específico — ele lê o `config.json` do repositório e verifica o método de
-quantização contra o que o `mlx-lm` aceita.
-
-### Apple Silicon
-
-Sim, funciona — e não há nada a configurar. Os artefatos contêm **pesos, não
-executáveis**: um `.gguf` ou `.safetensors` não tem arquitetura de CPU. Nem o
-manifesto do Ollama nem o artefato OCI declaram `platform`, então não existe o
-problema de "imagem sem build arm64" que afeta o `image_sync.yml` (esse sim
-espelha imagens Docker, onde a arquitetura importa).
-
-O que precisa ser nativo para Apple Silicon é o **cliente**, e Ollama, LM Studio
-e MLX têm builds arm64 oficiais. A única garantia que o espelho não pode dar é a
-do formato: veja a tabela acima.
+**Apple Silicon funciona sem configuração:** os artefatos são pesos, não
+binários — não declaram arquitetura de CPU. Veja
+[Apple Silicon](docs/03-clientes.md#apple-silicon).
 
 ---
 
 ## Workflows
 
-### `Sync HF Model to GHCR`
+| Workflow | Uso |
+|---|---|
+| `hf-model-to-ghcr.yml` | publica um modelo do Hugging Face |
+| `ollama-model-to-ghcr.yml` | espelha um modelo da biblioteca pública do Ollama, em streaming |
+| `image_sync.yml` | espelha imagens Docker do Docker Hub (multi-arquitetura, via `skopeo`) |
+| `helm_chart_sync.yml` | espelha Helm charts |
 
-Publica um repositório do Hugging Face. Informe o repo e rode:
+## Scripts
 
-| Input | Padrão | O que faz |
-|---|---|---|
-| `model_repo` | — | `bartowski/Qwen2.5-7B-Instruct-GGUF` |
-| `revision` | `main` | branch, tag ou commit |
-| `file_pattern` | `*.gguf` | qual quantização publicar (ex: `*Q4_K_M*.gguf`) |
-| `package_name` | nome do repo HF | nome do pacote no GHCR |
-| `tag` | quantização detectada | tag no GHCR (ex: `q4_k_m`) |
-| `publish_ollama` | `true` | publica o formato nativo do Ollama |
-| `publish_hf_snapshot` | `true` | publica o snapshot HF como artefato OCI |
-| `exclude` | — | padrões extras a ignorar |
-| `force_resync` | `false` | republica mesmo se a tag existir |
-
-Quando o repositório traz várias quantizações e `file_pattern` fica no padrão, o
-workflow escolhe uma (preferindo `Q4_K_M`) e lista as demais no log — daí é só
-rodar de novo com um padrão mais estreito.
-
-Repositórios **sem GGUF** (safetensors puro, incluindo os `mlx-community`)
-continuam funcionando: o snapshot HF é publicado normalmente e o Ollama tenta
-importar os safetensors direto, o que funciona nas arquiteturas que ele suporta.
-
-### `Sync Ollama Model to GHCR`
-
-Espelha um modelo da biblioteca pública do Ollama (`qwen3:8b`,
-`deepseek-r1:7b`, …). A cópia é feita em streaming, preservando o manifesto
-original — nada é reconstruído, então o resultado é idêntico ao upstream.
-
----
-
-## Como baixar
-
-O helper cobre todos os casos e só precisa de `bash` + `python3` (usa `oras`
-quando disponível, por ser mais rápido):
-
-```bash
-./scripts/pull-model.sh ghcr.io/italoag/qwen3:q4_k_m       --for ollama
-./scripts/pull-model.sh ghcr.io/italoag/qwen3:q4_k_m-hf    --for lmstudio
-./scripts/pull-model.sh ghcr.io/italoag/qwen3:q4_k_m-hf    --for mlx
-./scripts/pull-model.sh ghcr.io/italoag/qwen3:q4_k_m-hf    --out ./modelo
-```
-
-Para pacotes privados: `--user <usuário> --token <PAT com read:packages>`.
-
-### Ollama
-
-```bash
-ollama pull ghcr.io/italoag/qwen3:q4_k_m
-ollama run  ghcr.io/italoag/qwen3:q4_k_m
-```
-
-### LM Studio
-
-```bash
-./scripts/pull-model.sh ghcr.io/italoag/qwen3:q4_k_m-hf --for lmstudio
-lms ls
-lms load italoag/qwen3
-```
-
-O helper grava em `~/.lmstudio/models/<owner>/<pacote>/`, que é o layout que o
-LM Studio varre. A CLI `lms` não baixa de registros OCI — ela lê o diretório
-local, então o download é feito pelo helper e o `lms` só carrega.
-
-### MLX
-
-```bash
-./scripts/pull-model.sh ghcr.io/italoag/qwen3-4bit:latest-hf --out ./qwen3-4bit
-mlx_lm.generate --model ./qwen3-4bit --prompt "olá"
-```
-
-### transformers / vLLM / SGLang
-
-```bash
-oras pull ghcr.io/italoag/qwen3:latest-hf -o ./qwen3
-python -c "from transformers import AutoModelForCausalLM; AutoModelForCausalLM.from_pretrained('./qwen3')"
-```
-
-### llama.cpp
-
-```bash
-oras pull ghcr.io/italoag/qwen3:q4_k_m-hf -o ./qwen3
-llama-cli -m ./qwen3/Qwen3-Q4_K_M.gguf -p "olá"
-```
-
-### Agentes (OpenClaw, Pi, Hermes Agent, …)
-
-Esses clientes falam com um servidor compatível com a API da OpenAI, não com o
-registro. Puxe o modelo e sirva localmente:
-
-```bash
-ollama pull ghcr.io/italoag/qwen3:q4_k_m
-ollama serve            # expõe http://localhost:11434/v1
-```
-
-Aponte o agente para `http://localhost:11434/v1` com o nome do modelo
-`ghcr.io/italoag/qwen3:q4_k_m`. Com LM Studio, `lms server start` expõe o mesmo
-tipo de endpoint em `http://localhost:1234/v1`.
-
----
-
-## O pacote precisa ser público
-
-O `ollama pull` só obtém **token anônimo** em registros de terceiros — ele não
-tem como enviar credenciais do GHCR. Um pacote privado responde 403 e o pull
-falha, mesmo com o manifesto correto.
-
-**A visibilidade do pacote é independente da do repositório.** Ter o repositório
-público não basta: pacotes novos nascem **privados**, e a documentação do GitHub
-é explícita de que o pacote herda *as permissões de acesso, mas não a
-visibilidade* do repositório vinculado. Não existe endpoint REST (só há `GET`,
-`DELETE` e `POST /restore` em `/user/packages/...`) nem mutation GraphQL
-(só `deletePackageVersion`) para mudar visibilidade. Ou seja: **não dá para
-automatizar** — é a interface web ou nada.
-
-O que dá para fazer é pagar esse custo **uma única vez**:
-
-1. Publique todos os modelos como **tags de um mesmo pacote**, passando o mesmo
-   `package_name` em toda execução:
-
-   ```
-   model_repo   = bartowski/Qwen2.5-7B-Instruct-GGUF
-   package_name = models
-   ```
-
-   Isso gera `ghcr.io/italoag/models:qwen2.5-7b-instruct-gguf-q4_k_m`. Quando
-   `package_name` difere do nome derivado do repo HF, o nome do modelo entra na
-   tag automaticamente, então não há colisão entre modelos.
-
-2. Torne `models` público uma vez: **perfil → aba Packages → o pacote →
-   Package settings → Danger Zone → Change visibility → Public**. Toda tag
-   publicada depois nasce pública, sem passo manual.
-
-   ⚠️ Segundo a documentação do GitHub, tornar um pacote público é
-   **irreversível**.
-
-Se preferir um pacote por modelo (`ghcr.io/italoag/qwen3:q4_k_m`, mais bonito no
-`ollama list`), o passo manual se repete uma vez por modelo novo — nunca a cada
-sincronização. O passo de verificação do workflow detecta o caso e imprime o
-caminho exato a seguir.
-
-O snapshot `-hf` também precisa ser público para ser puxado sem credenciais, mas
-`oras` e o helper aceitam token — então ele funciona privado.
-
----
+| Script | Papel |
+|---|---|
+| `scripts/ghcr_ollama.py` | cliente do OCI Distribution API: `exists`, `push`, `mirror`, `pull`, `verify` |
+| `scripts/hf_resolve.py` | lê o repo HF e monta o `plan.json` (arquivos, pacote, tag, compatibilidade) |
+| `scripts/hf_download.py` | baixa só os arquivos do plano via `snapshot_download` |
+| `scripts/pull-model.sh` | helper de download para cada cliente |
+| `scripts/check_image.sh` | verificação manual de imagens Docker comuns |
 
 ## Secrets
 
@@ -212,22 +101,8 @@ O snapshot `-hf` também precisa ser público para ser puxado sem credenciais, m
 | `GHCR_PAT` | opcional | PAT com `write:packages`; tem precedência quando existe |
 | `HF_TOKEN` | opcional | modelos *gated* no Hugging Face (Llama, Gemma…) |
 
-Nenhum dos dois afeta a visibilidade do pacote — ela é sempre privada no
-primeiro push. A diferença é o vínculo: publicando com o `GITHUB_TOKEN` o
-pacote já nasce ligado a este repositório e as workflows daqui ganham acesso
-automático a ele.
-
----
-
-## Scripts
-
-| Script | Papel |
-|---|---|
-| `scripts/ghcr_ollama.py` | cliente do OCI Distribution API: `exists`, `push`, `mirror`, `pull`, `verify` |
-| `scripts/hf_resolve.py` | lê o repo HF e monta o `plan.json` (arquivos, nome do pacote, tag) |
-| `scripts/hf_download.py` | baixa só os arquivos do plano via `snapshot_download` |
-| `scripts/pull-model.sh` | helper de download para cada cliente |
-| `scripts/check_image.sh` | verificação manual de imagens Docker comuns |
+Nenhum deles afeta a visibilidade do pacote — ela é sempre privada no primeiro
+push.
 
 ---
 
@@ -245,12 +120,3 @@ Também importa o **formato da referência**: o Ollama só entende
 `host/namespace/modelo`. `ghcr.io/<owner>/mirror/<modelo>:<tag>` tem um nível a
 mais e não é sequer parseável — daí os pacotes ficarem em
 `ghcr.io/<owner>/<modelo>:<tag>`.
-
----
-
-## Outros workflows
-
-| Workflow | Uso |
-|---|---|
-| `image_sync.yml` | espelha imagens Docker do Docker Hub para o GHCR (multi-arquitetura, via `skopeo`) |
-| `helm_chart_sync.yml` | espelha Helm charts |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ binários — não declaram arquitetura de CPU. Veja
 | `ollama-model-to-ghcr.yml` | espelha um modelo da biblioteca pública do Ollama, em streaming |
 | `image_sync.yml` | espelha imagens Docker do Docker Hub (multi-arquitetura, via `skopeo`) |
 | `helm_chart_sync.yml` | espelha Helm charts |
+| `tests.yml` | compila os scripts, valida a sintaxe dos blocos `run:` e roda `tests/test_paths.py` |
 
 ## Scripts
 
@@ -92,6 +93,7 @@ binários — não declaram arquitetura de CPU. Veja
 | `scripts/hf_download.py` | baixa só os arquivos do plano via `snapshot_download` |
 | `scripts/pull-model.sh` | helper de download para cada cliente |
 | `scripts/check_image.sh` | verificação manual de imagens Docker comuns |
+| `tests/test_paths.py` | regressão do tratamento de caminhos vindos do registro e do Hugging Face |
 
 ## Secrets
 

--- a/docs/01-publicar.md
+++ b/docs/01-publicar.md
@@ -1,0 +1,185 @@
+# 1. Publicar um modelo
+
+Dois workflows, dependendo de onde o modelo está hoje.
+
+| Origem | Workflow |
+|---|---|
+| Hugging Face | `Sync HF Model to GHCR` |
+| Biblioteca pública do Ollama (`qwen3:8b`, `deepseek-r1:7b`…) | `Sync Ollama Model to GHCR` |
+
+---
+
+## Antes da primeira execução
+
+Três coisas, em ordem:
+
+1. **Escolha a estratégia de pacote.** [Guia 2](02-visibilidade.md). Isso define
+   o valor de `package_name` e não dá para desfazer depois.
+2. **Confira se o modelo serve para o seu cliente.** [Guia 4](04-escolher-modelo.md).
+   Espelhar um repo `*-GGUF` para usar no MLX é o erro mais comum, e não tem
+   conserto depois — MLX não lê GGUF.
+3. **Se o modelo for *gated*** (Llama, Gemma, alguns Mistral), crie o secret
+   `HF_TOKEN`. Veja abaixo.
+
+---
+
+## Sync HF Model to GHCR
+
+*Actions → Sync HF Model to GHCR → Run workflow.*
+
+### Inputs
+
+| Input | Padrão | Explicação |
+|---|---|---|
+| `model_repo` | — | O repo no Hugging Face, no formato `owner/nome`. Ex: `bartowski/Qwen2.5-7B-Instruct-GGUF` |
+| `revision` | `main` | Branch, tag ou commit. Fixe um commit se quiser reprodutibilidade |
+| `file_pattern` | `*.gguf` | Qual quantização publicar. Ex: `*Q5_K_M*.gguf` |
+| `package_name` | nome do repo HF | Pacote no GHCR. Um nome fixo agrupa todos os modelos num pacote só |
+| `tag` | quantização detectada | Tag no GHCR. Ex: `q4_k_m` |
+| `publish_ollama` | `true` | Publica o formato nativo do Ollama |
+| `publish_hf_snapshot` | `true` | Publica o snapshot HF como artefato OCI |
+| `exclude` | — | Padrões extras a ignorar, separados por vírgula |
+| `force_resync` | `false` | Republica mesmo se a tag já existir |
+
+### O que acontece, na ordem
+
+O workflow tem três jobs. O primeiro decide tudo antes de baixar um único byte —
+o que evita gastar vinte minutos puxando 40 GB para descobrir no fim que o
+padrão casava com seis quantizações.
+
+**Job `plan`.** Consulta a API do Hugging Face, lista os arquivos com tamanho,
+escolhe o grupo GGUF, deriva o nome do pacote e a tag, e publica no resumo da
+execução uma tabela de compatibilidade por cliente — lendo o `config.json` do
+repositório e conferindo o método de quantização. Também verifica o que já
+existe no GHCR, para pular o que não mudou.
+
+**Job `ollama`.** Baixa só os arquivos escolhidos, roda `ollama create` de
+verdade (é ele quem monta as camadas no formato certo), envia blobs e manifesto
+ao GHCR e valida o resultado com um pull anônimo.
+
+**Job `snapshot`.** Baixa o layout do Hugging Face e publica como artefato OCI,
+um arquivo por camada.
+
+Os dois últimos rodam em paralelo, em runners separados — cada um com seu
+próprio disco.
+
+### Como a tag é escolhida
+
+Se você não passar `tag`, ela vem da quantização detectada no nome do arquivo:
+
+```
+Qwen2.5-7B-Instruct-Q4_K_M.gguf   → tag q4_k_m
+Llama-3.2-3B-IQ3_XXS.gguf         → tag iq3_xxs
+```
+
+Num repo só de safetensors, a tag vira `safetensors`. Se nada for detectado,
+`latest`.
+
+**Com `package_name` diferente do nome derivado do repo** (o modo de pacote
+compartilhado), o nome do modelo entra na tag automaticamente, senão `q4_k_m`
+colidiria entre modelos diferentes:
+
+```
+bartowski/Qwen2.5-7B-Instruct-GGUF + package_name=models
+  → ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+```
+
+### Quando o repo tem várias quantizações
+
+Com `file_pattern` no padrão `*.gguf`, o workflow escolhe uma — preferindo
+`Q4_K_M`, e em empate a menor — e lista as outras no log:
+
+```
+🧩 GGUF escolhido: Qwen2.5-7B-Instruct-Q4_K_M.gguf
+   outras quantizações disponíveis (use file_pattern para escolher):
+     - Qwen2.5-7B-Instruct-Q5_K_M.gguf
+     - Qwen2.5-7B-Instruct-Q8_0.gguf
+```
+
+Para publicar outra, rode de novo com `file_pattern = *Q5_K_M*.gguf`. Como a tag
+sai diferente (`q5_k_m`), as duas convivem no mesmo pacote.
+
+### Modelos divididos em shards
+
+Arquivos `...-00001-of-00003.gguf` são tratados como um conjunto único: o
+workflow agrupa, baixa todos e passa todos ao `ollama create`, que os junta.
+Nada a fazer manualmente.
+
+### Modelos multimodais
+
+Um `mmproj-*.gguf` no repositório é detectado e vira uma camada de projetor no
+manifesto do Ollama, automaticamente.
+
+### Repositórios sem GGUF
+
+Repos só de safetensors (incluindo os `mlx-community/*`) funcionam: o snapshot
+HF é publicado normalmente, e o Ollama tenta importar os safetensors direto — o
+que funciona nas arquiteturas que ele já implementa, e falha alto quando não.
+
+---
+
+## Sync Ollama Model to GHCR
+
+Espelha um modelo da biblioteca pública do Ollama.
+
+| Input | Padrão | Explicação |
+|---|---|---|
+| `model_name` | — | `qwen3`, `deepseek-r1`, `llama3.2` |
+| `model_tag` | `latest` | `8b`, `7b`, `latest` |
+| `package_name` | o nome do modelo | Pacote no GHCR |
+| `tag` | a tag do modelo | Tag no GHCR |
+| `force_resync` | `false` | Republica mesmo se já existir |
+
+A cópia é feita em streaming, direto de `registry.ollama.ai` para o GHCR, sem
+tocar o disco do runner — então modelos de dezenas de GB passam sem problema. O
+manifesto original é preservado byte a byte: o resultado é idêntico ao upstream.
+
+---
+
+## Secrets
+
+| Secret | Necessário? | Para quê |
+|---|---|---|
+| `GITHUB_TOKEN` | automático | Publicar no GHCR. Vincula o pacote a este repositório |
+| `GHCR_PAT` | opcional | PAT com `write:packages`. Tem precedência quando existe |
+| `HF_TOKEN` | opcional | Modelos *gated* no Hugging Face |
+
+**Nenhum dos dois primeiros afeta a visibilidade do pacote** — ela é sempre
+privada no primeiro push. Veja o [guia 2](02-visibilidade.md).
+
+### Criando o `HF_TOKEN`
+
+Necessário para Llama, Gemma e outros modelos que exigem aceitar uma licença.
+
+1. Aceite a licença na página do modelo no Hugging Face, logado.
+2. Gere um token em *Settings → Access Tokens* com permissão de leitura.
+3. Neste repositório: *Settings → Secrets and variables → Actions → New
+   repository secret*, nome `HF_TOKEN`.
+
+Sem ele, um repo gated falha logo no job `plan`, com a mensagem apontando isso.
+
+---
+
+## Limites de espaço
+
+Os jobs trabalham em `/mnt` (~65 GB no runner do GitHub) em vez do disco raiz
+(~20 GB), e checam o espaço antes de baixar. Se não couber, a execução falha
+cedo com uma mensagem clara em vez de morrer no meio:
+
+```
+❌ /mnt tem 62 GiB livres, o modelo precisa de ~97 GiB.
+   Escolha uma quantização menor com o input file_pattern.
+```
+
+O job do Ollama precisa do modelo **duas vezes** (o arquivo baixado mais a cópia
+que o `ollama create` grava no diretório de blobs), então o teto prático é um
+GGUF de aproximadamente 28 GB. Na prática isso cobre até uns 70B em `Q3_K_M`.
+Para modelos maiores, publique só o snapshot HF (`publish_ollama = false`), que
+precisa do espaço uma vez só.
+
+---
+
+## Republicar
+
+Uma tag que já existe é pulada. Para forçar, marque `force_resync`. Útil quando
+o repositório de origem mudou sem trocar de tag.

--- a/docs/02-visibilidade.md
+++ b/docs/02-visibilidade.md
@@ -1,0 +1,169 @@
+# 2. Deixar o pacote público (e mantê-lo assim)
+
+> **Leia antes da primeira execução.** A decisão da estratégia muda o que você
+> faz agora, e tornar um pacote público é **irreversível** segundo a
+> documentação do GitHub.
+
+---
+
+## Por que isso importa
+
+O `ollama pull` só consegue **token anônimo** em registros de terceiros. Ele não
+tem para onde enviar credenciais do GHCR — não existe `ollama login ghcr.io`.
+Num pacote privado o registro responde 403 e o pull falha, mesmo com o manifesto
+perfeitamente correto.
+
+Ou seja: **pacote privado = `ollama pull` não funciona.** Sem exceção.
+
+(Para a tag `-hf` isso não é obrigatório: `oras` e o helper deste repositório
+aceitam token, então ela funciona privada. Mas exige credencial em toda máquina
+que for baixar.)
+
+---
+
+## A pegadinha: repositório público ≠ pacote público
+
+Este é o ponto que engana praticamente todo mundo.
+
+> "the package automatically inherits the access **permissions (but not the
+> visibility)** of the linked repository"
+>
+> "When you first publish a package that is scoped to your personal account,
+> **the default visibility is private**"
+>
+> — [documentação do GitHub](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility)
+
+Ter o repositório público **não torna o pacote público**. O que é herdado são as
+permissões de acesso, não a visibilidade. Todo pacote novo nasce privado.
+
+## E não dá para automatizar
+
+Não é limitação deste repositório, é do GitHub:
+
+- **REST API** — os únicos endpoints de packages são `GET`, `DELETE` e
+  `POST /restore`, em `/user/packages/...`, `/orgs/{org}/packages/...` e
+  `/users/{username}/packages/...`. **Não existe `PATCH` de visibilidade.**
+- **GraphQL** — o schema tem apenas `deletePackageVersion`. Não existe sequer um
+  tipo `PackageVisibility`.
+
+A troca só existe na interface web. Qualquer tutorial que prometa automatizar
+isso com um PAT está errado ou desatualizado.
+
+---
+
+## A estratégia: pagar uma vez, não sempre
+
+Como o passo manual é **por pacote**, e não por tag, dá para reduzi-lo a uma
+única vez na vida — publicando todos os modelos como tags de um mesmo pacote.
+
+### Opção A — pacote compartilhado (recomendada)
+
+Passe o mesmo `package_name` em toda execução:
+
+```
+model_repo   = bartowski/Qwen2.5-7B-Instruct-GGUF
+package_name = models
+```
+
+```
+ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+ghcr.io/<owner>/models:llama-3.2-3b-gguf-q4_k_m
+ghcr.io/<owner>/models:qwen3-8b-4bit-safetensors
+```
+
+Você torna `models` público **uma vez**. Toda tag publicada depois já nasce
+pública.
+
+- ✅ Um único passo manual, para sempre
+- ✅ Impossível esquecer e descobrir só na hora de usar
+- ❌ No `ollama list` tudo aparece como `ghcr.io/<owner>/models:...`
+
+O incômodo do nome resolve-se com um alias local:
+
+```bash
+ollama pull ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+ollama cp   ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m qwen
+ollama run  qwen
+```
+
+### Opção B — um pacote por modelo
+
+Deixe `package_name` vazio:
+
+```
+ghcr.io/<owner>/qwen2.5-7b-instruct-gguf:q4_k_m
+ghcr.io/<owner>/llama-3.2-3b-gguf:q4_k_m
+```
+
+- ✅ Nomes limpos, organização por modelo, dá para apagar um modelo inteiro
+- ❌ Um passo manual **por modelo novo** (nunca por sincronização — quantizações
+  novas do mesmo modelo entram na mesma caixa, já pública)
+
+---
+
+## Passo a passo para tornar público
+
+Faça isso **depois** da primeira execução do workflow — o pacote precisa existir.
+
+1. Abra `https://github.com/<seu-usuário>?tab=packages`
+   (numa organização: página da org → aba **Packages**).
+2. Clique no pacote.
+3. Na direita, **Package settings**.
+4. Role até **Danger Zone** → **Change visibility**.
+5. Escolha **Public**.
+6. Digite o nome do pacote para confirmar.
+
+> ⚠️ **Irreversível.** A documentação do GitHub é explícita: *"Once you make a
+> package public, you cannot make it private again."*
+
+---
+
+## Conferir que deu certo
+
+O script faz a verificação **sem credenciais** — exatamente o caminho que o
+Ollama percorre, incluindo o redirect dos blobs para a CDN. Se isso passa,
+qualquer máquina no mundo consegue baixar:
+
+```bash
+python3 scripts/ghcr_ollama.py verify \
+  --repository <owner>/models --tag qwen2.5-7b-instruct-gguf-q4_k_m
+```
+
+Público e correto:
+
+```
+✅ manifesto Ollama OK (5 blobs): application/vnd.ollama.image.model, ...
+✅ todos os 5 blobs acessíveis anonimamente
+👉 ollama pull ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+```
+
+Ainda privado (código de saída 2):
+
+```
+⚠️  O pacote <owner>/models ainda está PRIVADO. O manifesto foi publicado,
+    mas o `ollama pull` não vai funcionar: ...
+```
+
+Funciona igual para a tag `-hf`, reportando que é um artefato OCI.
+
+O próprio workflow roda essa verificação ao final de cada publicação, então o
+resumo da execução já diz se está tudo certo. Ela não derruba o job — a
+publicação em si deu certo; o que falta é a visibilidade.
+
+---
+
+## Checklist
+
+Antes da primeira execução:
+
+- [ ] Estratégia escolhida (A ou B) e `package_name` definido
+- [ ] `HF_TOKEN` criado, se o modelo for gated
+
+Depois da primeira execução:
+
+- [ ] Pacote tornado público na interface web
+- [ ] `verify` passando sem credenciais
+- [ ] `ollama pull` testado numa máquina limpa (ou com `ollama rm` antes, para
+      não confundir cache local com download real)
+
+Nas execuções seguintes: nada. Só publicar.

--- a/docs/03-clientes.md
+++ b/docs/03-clientes.md
@@ -1,0 +1,275 @@
+# 3. Usar nos clientes
+
+Todos os exemplos assumem macOS com Apple Silicon, mas nada aqui é específico de
+arquitetura — veja [Apple Silicon](#apple-silicon) no fim.
+
+Substitua `<owner>` pelo seu usuário do GitHub.
+
+---
+
+## O helper
+
+Cobre todos os clientes e só precisa de `bash` + `python3`. Se o `oras` estiver
+instalado ele é usado, por ser mais rápido; senão o download cai no
+`scripts/ghcr_ollama.py`.
+
+```bash
+git clone https://github.com/<owner>/mirror.git
+cd mirror
+
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-q4_k_m       --for ollama
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-q4_k_m-hf    --for lmstudio
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-4bit-hf      --for mlx
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-q4_k_m-hf    --out ./modelo
+```
+
+Pacote privado: acrescente `--user <usuário> --token <PAT com read:packages>`.
+
+As seções abaixo mostram o que fazer sem o helper, se você preferir.
+
+---
+
+## Ollama
+
+Use a tag **sem** `-hf`.
+
+```bash
+brew install ollama          # ou https://ollama.com/download
+ollama serve &               # o app do macOS já sobe o serviço sozinho
+
+ollama pull ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+ollama run  ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+```
+
+### Um nome curto
+
+O nome completo é chato de digitar. `ollama cp` cria um alias local:
+
+```bash
+ollama cp ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m qwen
+ollama run qwen
+```
+
+### Servidor compatível com OpenAI
+
+O Ollama expõe endpoints OpenAI em `http://localhost:11434/v1`:
+`/v1/chat/completions`, `/v1/completions`, `/v1/models`.
+
+```bash
+curl http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen","messages":[{"role":"user","content":"olá"}]}'
+```
+
+### Variáveis úteis
+
+| Variável | Para quê |
+|---|---|
+| `OLLAMA_HOST` | Endereço do servidor (padrão `127.0.0.1:11434`) |
+| `OLLAMA_MODELS` | Onde guardar os modelos — aponte para um disco externo |
+| `OLLAMA_KEEP_ALIVE` | Quanto tempo o modelo fica na memória (padrão `5m`) |
+| `OLLAMA_CONTEXT_LENGTH` | Contexto padrão |
+
+---
+
+## LM Studio
+
+Use a tag **`-hf`**. O LM Studio lê tanto GGUF quanto modelos MLX.
+
+Ele varre `~/.lmstudio/models/` esperando a estrutura
+`<publisher>/<model>/arquivo`, que é exatamente a que o helper monta:
+
+```bash
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m-hf --for lmstudio
+```
+
+Depois, no app: aba **My Models** → o modelo aparece. Pela CLI:
+
+```bash
+lms ls                      # lista o que está baixado
+lms ls --detailed
+lms load <owner>/models     # carrega na memória
+lms load <owner>/models --gpu max --context-length 8192 --ttl 3600
+lms unload
+```
+
+### Alternativa: `lms import`
+
+Se você já baixou o `.gguf` para qualquer lugar, o LM Studio importa direto:
+
+```bash
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-q4_k_m-hf --out ./tmp
+lms import ./tmp/Qwen2.5-7B-Instruct-Q4_K_M.gguf --user-repo <owner>/qwen2.5-7b -y
+```
+
+Flags úteis: `-c/--copy`, `-L/--hard-link`, `-l/--symbolic-link` (economiza
+espaço), `--dry-run`.
+
+### Servidor local
+
+```bash
+lms server start                       # porta padrão
+lms server start --port 1234 --cors
+lms server status
+lms server stop
+```
+
+---
+
+## MLX
+
+Use a tag **`-hf`** — e o modelo de origem **precisa ser safetensors**. O
+`mlx-lm` faz `glob("model*.safetensors")` e aborta se não achar. Ele não lê GGUF.
+Veja [Escolher o modelo certo](04-escolher-modelo.md).
+
+```bash
+pip install mlx-lm
+
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-8b-4bit-safetensors-hf --out ./qwen3-4bit
+
+mlx_lm.generate --model ./qwen3-4bit --prompt "explique o que é MLX"
+mlx_lm.chat --model ./qwen3-4bit
+```
+
+Os subcomandos existem nas duas formas — `mlx_lm.generate` ou `mlx_lm generate`.
+
+### Servidor compatível com OpenAI
+
+```bash
+mlx_lm.server --model ./qwen3-4bit          # porta 8080 por padrão
+```
+
+### Modelos grandes na memória unificada
+
+O `mlx-lm` já ajusta sozinho o limite de memória *wired* (precisa de macOS 15+).
+Se aparecer:
+
+```
+[WARNING] Generating with a model that requires NNNN MB which is close to the
+maximum recommended size of MMMM MB. This can be slow.
+```
+
+o modelo cabe na RAM, mas está perto do teto que o Metal recomenda. A saída
+documentada pelo próprio mlx-lm é subir o limite do sistema:
+
+```bash
+sudo sysctl iogpu.wired_limit_mb=N
+```
+
+`N` maior que o tamanho do modelo em MB e menor que a RAM total da máquina. Num
+Mac de 32 GB, algo como `24576`. O efeito some ao reiniciar.
+
+---
+
+## llama.cpp
+
+Use a tag **`-hf`**, e o modelo precisa ser GGUF.
+
+```bash
+brew install llama.cpp
+
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-q4_k_m-hf --out ./qwen3
+llama-cli   -m ./qwen3/Qwen2.5-7B-Instruct-Q4_K_M.gguf -p "olá"
+llama-server -m ./qwen3/Qwen2.5-7B-Instruct-Q4_K_M.gguf --port 8080
+```
+
+Em GGUF dividido em shards, aponte para o **primeiro** (`-00001-of-0000N`); o
+llama.cpp acha o resto sozinho.
+
+---
+
+## transformers / vLLM / SGLang
+
+Use a tag **`-hf`**, com modelo safetensors.
+
+```bash
+brew install oras
+oras pull ghcr.io/<owner>/models:qwen3-8b-safetensors-hf -o ./qwen3
+```
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+tok = AutoTokenizer.from_pretrained("./qwen3")
+model = AutoModelForCausalLM.from_pretrained("./qwen3", device_map="auto")
+```
+
+```bash
+vllm serve ./qwen3
+```
+
+---
+
+## Agentes (OpenClaw, Pi, Hermes Agent, Continue, Aider…)
+
+Esses clientes **não falam com registros de container** — eles falam com um
+servidor compatível com a API da OpenAI. O caminho é: puxe o modelo, suba um
+servidor local, aponte o agente para ele.
+
+```bash
+ollama pull ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+ollama cp   ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m qwen
+ollama serve
+```
+
+Configure o agente com:
+
+| Campo | Valor |
+|---|---|
+| Base URL | `http://localhost:11434/v1` |
+| API key | qualquer string não vazia (o Ollama ignora) |
+| Model | `qwen` |
+
+Alternativas equivalentes:
+
+| Servidor | Base URL |
+|---|---|
+| Ollama | `http://localhost:11434/v1` |
+| LM Studio (`lms server start`) | `http://localhost:1234/v1` |
+| MLX (`mlx_lm.server`) | `http://localhost:8080/v1` |
+| llama.cpp (`llama-server`) | `http://localhost:8080/v1` |
+
+---
+
+## Pacotes privados
+
+Se você optou por não tornar o pacote público, o `ollama pull` **não vai
+funcionar** — não há como passar credenciais. Os demais clientes funcionam, via
+o snapshot `-hf`:
+
+```bash
+export GHCR_USERNAME=<seu-usuário>
+export GHCR_TOKEN=<PAT com read:packages>
+
+./scripts/pull-model.sh ghcr.io/<owner>/models:qwen3-q4_k_m-hf --out ./modelo
+```
+
+Com `oras` direto:
+
+```bash
+echo "$GHCR_TOKEN" | oras login ghcr.io --username "$GHCR_USERNAME" --password-stdin
+oras pull ghcr.io/<owner>/models:qwen3-q4_k_m-hf -o ./modelo
+```
+
+Para o Ollama, o helper contorna: baixa o snapshot `-hf` (que aceita token) e
+reconstrói o modelo localmente com `ollama create`. É automático — basta usar
+`--for ollama` e deixar o fallback agir.
+
+---
+
+## Apple Silicon
+
+**Funciona, e não há nada a configurar.**
+
+Os artefatos contêm **pesos, não executáveis**. Um `.gguf` ou um `.safetensors`
+não tem arquitetura de CPU. Nem o manifesto do Ollama nem o artefato OCI
+declaram `platform`, então o problema clássico de "imagem sem build arm64"
+simplesmente não existe aqui. (Ele existe no `image_sync.yml`, que espelha
+imagens Docker de verdade — outra coisa.)
+
+O que precisa ser nativo arm64 é o **cliente**, e Ollama, LM Studio, MLX e
+llama.cpp têm builds oficiais para Apple Silicon.
+
+A única garantia que o espelho não pode dar é a de **formato**: se você espelhar
+um repo GGUF e tentar usar no MLX, não vai funcionar em máquina nenhuma. Isso é
+o assunto do [guia 4](04-escolher-modelo.md).

--- a/docs/04-escolher-modelo.md
+++ b/docs/04-escolher-modelo.md
@@ -1,0 +1,150 @@
+# 4. Escolher o modelo certo
+
+O espelhamento **não converte nada**: ele copia fielmente o formato que existe no
+Hugging Face. Então a compatibilidade é decidida no momento em que você escolhe
+o `model_repo` — não depois.
+
+---
+
+## A regra que mais pega gente
+
+> **MLX não lê GGUF.**
+
+O `mlx-lm` procura os pesos com `glob("model*.safetensors")` e aborta com
+`No safetensors found` se não achar. No código dele, GGUF aparece **só como
+destino de exportação** (`mlx_lm.fuse --export-gguf`); não existe caminho de
+leitura.
+
+Isso não é limitação deste repositório — baixando direto do Hugging Face é
+igual. Se o seu alvo é MLX, você precisa espelhar um repositório de safetensors.
+
+---
+
+## Matriz por formato de origem
+
+| Origem no Hugging Face | Ollama | llama.cpp | LM Studio | MLX | transformers |
+|---|:--:|:--:|:--:|:--:|:--:|
+| `*-GGUF` (bartowski, unsloth, lmstudio-community) | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `mlx-community/*` (quantizado em MLX) | ⚠️ | ❌ | ✅ | ✅ | ✅ |
+| safetensors fp16/bf16 (o repo oficial do modelo) | ⚠️ | ❌ | ❌ | ✅ | ✅ |
+| AWQ / GPTQ / MXFP4 / bitnet | ⚠️ | ❌ | ❌ | ✅ | ✅ |
+| bitsandbytes 4/8-bit | ⚠️ | ❌ | ❌ | ❌ | ✅ |
+
+⚠️ = o Ollama importa safetensors, mas só nas arquiteturas que ele já
+implementa. O workflow tenta e falha alto se não der.
+
+O job `plan` publica essa tabela **já resolvida para o modelo específico** no
+resumo de cada execução: ele lê o `config.json` do repositório e confere o método
+de quantização contra o que o `mlx-lm` aceita. Se estiver em dúvida, rode e leia
+o resumo antes de se comprometer.
+
+---
+
+## Como decidir, na prática
+
+### "Quero rodar no Ollama"
+
+Espelhe um repo `*-GGUF`. Os publicadores confiáveis são `bartowski`, `unsloth`,
+`lmstudio-community` e o `ggml-org`.
+
+```
+model_repo   = bartowski/Qwen2.5-7B-Instruct-GGUF
+file_pattern = *Q4_K_M*.gguf
+```
+
+Alternativa mais simples ainda: se o modelo já está na biblioteca do Ollama, use
+o workflow `Sync Ollama Model to GHCR` — é streaming puro, sem build.
+
+### "Quero rodar no MLX"
+
+Espelhe o `mlx-community/*` correspondente.
+
+```
+model_repo = mlx-community/Qwen3-8B-4bit
+```
+
+Esses repos já vêm quantizados em formato MLX, com o bloco `quantization` no
+`config.json`. Carregam rápido e ocupam pouca RAM.
+
+Se não existir versão MLX do modelo, espelhe o repo oficial em fp16/bf16 — o
+`mlx-lm` converte ao carregar. Custa mais RAM e mais tempo de carga.
+
+### "Quero cobrir tudo no meu Mac"
+
+**Espelhe dois repositórios.** São modelos diferentes no Hugging Face, então são
+duas execuções do workflow:
+
+```
+1)  model_repo = bartowski/Qwen2.5-7B-Instruct-GGUF   → Ollama, LM Studio, llama.cpp
+2)  model_repo = mlx-community/Qwen2.5-7B-Instruct-4bit → MLX, LM Studio, transformers
+```
+
+Com a estratégia de pacote compartilhado, os dois convivem no mesmo pacote:
+
+```
+ghcr.io/<owner>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+ghcr.io/<owner>/models:qwen2.5-7b-instruct-4bit-safetensors
+```
+
+### "Quero servir com vLLM num servidor"
+
+Espelhe o repo oficial em safetensors (fp16/bf16), ou uma versão AWQ/GPTQ.
+Desligue `publish_ollama` para poupar metade do tempo e do disco.
+
+---
+
+## Escolher a quantização
+
+Valores aproximados por peso, e o tamanho resultante num modelo de 7–8 B:
+
+| Quantização | ~bits/peso | 7–8 B | Comentário |
+|---|:--:|:--:|---|
+| `Q8_0` | ~8.5 | ~8 GB | Quase idêntico ao fp16. Raramente vale o custo |
+| `Q6_K` | ~6.6 | ~6 GB | Perda imperceptível |
+| `Q5_K_M` | ~5.7 | ~5.5 GB | Bom meio-termo |
+| **`Q4_K_M`** | ~4.8 | ~4.5 GB | **Padrão da casa.** Melhor relação qualidade/tamanho |
+| `IQ4_XS` | ~4.3 | ~4 GB | Um pouco menor, um pouco mais lento |
+| `Q3_K_M` | ~3.9 | ~3.5 GB | Degradação já perceptível |
+| MLX 4-bit | ~4.5 | ~4.5 GB | Equivalente ao Q4_K_M, no mundo MLX |
+
+Regra de bolso: `tamanho ≈ parâmetros × bits_por_peso ÷ 8`.
+
+Sem `file_pattern`, o workflow escolhe `Q4_K_M` quando existe.
+
+---
+
+## Quanto cabe na sua máquina
+
+Some o tamanho do modelo **mais o contexto** (o cache KV, que cresce com o
+tamanho da janela) e deixe folga para o sistema. Numa memória unificada de Apple
+Silicon, o Metal recomenda usar até cerca de 75% da RAM total.
+
+| RAM do Mac | Confortável | No limite |
+|---|---|---|
+| 8 GB | 3–4 B em Q4_K_M | 7 B em Q4_K_M, contexto curto |
+| 16 GB | 7–8 B em Q4_K_M | 14 B em Q4_K_M |
+| 24 GB | 14 B em Q4_K_M | 32 B em Q4_K_M |
+| 32 GB | 14 B em Q6_K, ou 32 B em Q4_K_M | 32 B em Q5_K_M |
+| 64 GB+ | 32 B em Q6_K | 70 B em Q4_K_M |
+
+Passando do limite, o Ollama descarrega camadas para a CPU e o llama.cpp faz
+paginação — em ambos os casos a geração desaba de dezenas para poucos tokens por
+segundo. O MLX avisa explicitamente com o `[WARNING]` descrito no
+[guia 3](03-clientes.md#modelos-grandes-na-memória-unificada).
+
+---
+
+## Limites do runner
+
+O job do Ollama precisa do modelo **duas vezes** em disco (o download mais a
+cópia no diretório de blobs), num `/mnt` de ~65 GB. Teto prático: GGUF de até uns
+28 GB.
+
+Para modelos maiores, publique só o snapshot HF:
+
+```
+publish_ollama = false
+```
+
+Ele precisa do espaço uma vez só, o que dobra o teto. O workflow checa isso antes
+de baixar e falha cedo com a conta feita, em vez de morrer no meio.

--- a/docs/05-erros-comuns.md
+++ b/docs/05-erros-comuns.md
@@ -1,0 +1,206 @@
+# 5. Erros comuns
+
+Organizado por sintoma. As mensagens abaixo são as reais, produzidas pelos
+scripts deste repositório ou pelos próprios clientes.
+
+---
+
+## Na publicação (GitHub Actions)
+
+### `acesso negado ao repositório X (HTTP 401)`
+
+```
+acesso negado ao repositório meta-llama/Llama-3.2-3B (HTTP 401).
+Se o modelo é gated, configure o secret HF_TOKEN com um token que aceitou a licença.
+```
+
+O modelo exige aceitar uma licença. **Aceitar a licença logado no Hugging Face
+não basta** — o token também precisa existir aqui:
+
+1. Aceite a licença na página do modelo, logado.
+2. Gere um token de leitura em *Settings → Access Tokens*.
+3. Crie o secret `HF_TOKEN` neste repositório.
+
+Um token gerado **antes** de você aceitar a licença funciona; o que importa é a
+conta dona do token ter aceitado.
+
+### `repositório X (revisão main) não encontrado`
+
+Erro de digitação no `model_repo`, ou repositório privado. O formato é
+`owner/nome` — copie da URL do Hugging Face, sem o `https://huggingface.co/`.
+
+### `❌ /mnt tem 62 GiB livres, o modelo precisa de ~97 GiB`
+
+O modelo não cabe no runner. Nesta ordem:
+
+1. Escolha uma quantização menor: `file_pattern = *Q3_K_M*.gguf`
+2. Publique só o snapshot HF: `publish_ollama = false` (dobra o teto, porque não
+   há a segunda cópia que o `ollama create` grava)
+3. Se ainda não couber, o modelo é grande demais para runners do GitHub.
+
+### `unexpected status code 403 Forbidden` no push
+
+O token não tem permissão de escrita **naquele pacote**. Causa mais comum: o
+pacote já existe, criado antes com um PAT, e agora o `GITHUB_TOKEN` não o
+alcança porque ele não está vinculado a este repositório.
+
+Configure o secret `GHCR_PAT` com um PAT clássico com escopo `write:packages` —
+ele tem precedência sobre o `GITHUB_TOKEN`.
+
+### O job `ollama` falha em `ollama create`
+
+Duas causas possíveis, e o log distingue:
+
+- **`unsupported content type` / `only GGUF supported`** — o repositório é de
+  safetensors numa arquitetura que o Ollama ainda não importa. Solução: publique
+  só o snapshot (`publish_ollama = false`) e use MLX, LM Studio ou transformers.
+- **Erro de arquitetura desconhecida** — modelo novo demais para a versão do
+  Ollama instalada no runner. Costuma resolver sozinho quando o Ollama lança
+  suporte; enquanto isso, espelhe uma versão GGUF do modelo.
+
+### `nenhum GGUF casou com '*Q4_K_M*.gguf'`
+
+Não é erro fatal — o workflow segue publicando o snapshot. Mas se você queria o
+GGUF, o padrão não bateu. Rode uma vez com `file_pattern = *.gguf` e leia o log:
+ele lista todos os candidatos com o nome exato.
+
+---
+
+## Na hora de baixar
+
+### `Error: pull model manifest: 401` ou `403` no `ollama pull`
+
+**O pacote está privado.** É de longe o erro mais comum.
+
+O `ollama pull` só consegue token anônimo em registros de terceiros — não existe
+`ollama login ghcr.io`. Siga o [guia 2](02-visibilidade.md) para tornar o pacote
+público. Confirme com:
+
+```bash
+python3 scripts/ghcr_ollama.py verify --repository <owner>/<pacote> --tag <tag>
+```
+
+### `Error: pull model manifest: 404` / `manifest unknown`
+
+A tag não existe. Confira o nome exato no resumo da execução do workflow — em
+pacote compartilhado a tag inclui o nome do modelo
+(`qwen2.5-7b-instruct-gguf-q4_k_m`, não `q4_k_m`).
+
+### O `ollama pull` não aceita a referência
+
+```
+Error: invalid model name
+```
+
+O Ollama entende exatamente **`host/namespace/modelo:tag`** — três níveis, nunca
+quatro. Isto não funciona:
+
+```
+ghcr.io/<owner>/mirror/qwen3:8b     ❌ um nível a mais, nem é parseável
+```
+
+Isto funciona:
+
+```
+ghcr.io/<owner>/qwen3:8b            ✅
+ghcr.io/<owner>/models:qwen3-8b     ✅
+```
+
+Os workflows deste repositório já produzem só o formato correto. Se você viu o
+formato errado, é uma referência antiga.
+
+### O download trava ou cai no meio
+
+O GHCR redireciona os blobs para `pkg-containers.githubusercontent.com`. Se sua
+rede bloqueia esse domínio, o manifesto baixa e os pesos não. Libere o domínio no
+proxy ou firewall.
+
+### `digest divergente em <arquivo>`
+
+Download corrompido. O script apaga o arquivo parcial e aborta em vez de entregar
+peso corrompido. Rode de novo — arquivos já verificados são pulados.
+
+---
+
+## Nos clientes
+
+### MLX: `FileNotFoundError: No safetensors found in <path>`
+
+**Você espelhou um repositório GGUF.** MLX não lê GGUF, ponto.
+
+Espelhe o `mlx-community/*` correspondente, ou o repo oficial em safetensors.
+Veja o [guia 4](04-escolher-modelo.md).
+
+### MLX: `[WARNING] Generating with a model that requires NNNN MB...`
+
+O modelo cabe na RAM, mas está perto do teto recomendado pelo Metal — a geração
+vai ficar lenta. A saída documentada pelo mlx-lm (macOS 15+):
+
+```bash
+sudo sysctl iogpu.wired_limit_mb=N
+```
+
+`N` maior que o modelo em MB e menor que a RAM total. Ou use uma quantização
+menor.
+
+### LM Studio não enxerga o modelo
+
+Ele espera exatamente **dois níveis** de diretório dentro de `~/.lmstudio/models/`:
+
+```
+~/.lmstudio/models/
+└── publisher/
+    └── model/
+        └── arquivo.gguf
+```
+
+Um nível a mais ou a menos e o modelo não aparece. O helper (`--for lmstudio`)
+monta isso corretamente. Se você baixou à mão, use `lms import` em vez de mover
+arquivos:
+
+```bash
+lms import ./arquivo.gguf --user-repo <publisher>/<model> -y
+```
+
+Depois de mexer no diretório, dê um **Refresh** na aba *My Models*.
+
+### LM Studio não carrega um modelo MLX
+
+O motor MLX só existe em Apple Silicon. Em Intel ou Windows, use GGUF.
+
+### llama.cpp: modelo em shards
+
+Aponte para o **primeiro** arquivo (`-00001-of-0000N.gguf`); o llama.cpp
+encontra os outros sozinho. Passar o segundo shard dá erro de arquivo inválido.
+
+### O agente não conecta
+
+Agentes falam com a API da OpenAI, não com o registro. Confira:
+
+- O servidor está de pé? (`ollama serve`, `lms server start`, `mlx_lm.server`)
+- A Base URL termina em `/v1`?
+- O nome do modelo no agente é o mesmo do `ollama list`?
+- Alguma API key preenchida? Muitos clientes exigem string não vazia mesmo que o
+  servidor ignore.
+
+---
+
+## Diagnóstico rápido
+
+Antes de abrir uma issue, estes três comandos localizam quase tudo:
+
+```bash
+# 1. A tag existe e está pública?  (sem credenciais, como o Ollama faria)
+python3 scripts/ghcr_ollama.py verify --repository <owner>/<pacote> --tag <tag>
+
+# 2. O que existe nesse pacote?
+oras repo tags ghcr.io/<owner>/<pacote>
+
+# 3. O que tem dentro da tag?
+oras manifest fetch --pretty ghcr.io/<owner>/<pacote>:<tag>
+```
+
+O `verify` é o mais útil dos três: ele refaz exatamente o caminho do
+`ollama pull` — desafio de autenticação, manifesto, media types das camadas e um
+`Range` de 1 byte em cada blob para confirmar o redirect até a CDN — sem baixar
+os gigabytes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,68 @@
+# Documentação
+
+Guia completo para espelhar modelos de LLM no GHCR e consumi-los localmente.
+
+| Guia | Quando ler |
+|---|---|
+| [1. Publicar um modelo](01-publicar.md) | primeira vez rodando o workflow |
+| [2. Deixar o pacote público](02-visibilidade.md) | **leia antes da primeira execução** — a escolha aqui é irreversível |
+| [3. Usar nos clientes](03-clientes.md) | Ollama, LM Studio, MLX, llama.cpp, transformers, agentes |
+| [4. Escolher o modelo certo](04-escolher-modelo.md) | qual repo do HF espelhar para o seu caso e sua máquina |
+| [5. Erros comuns](05-erros-comuns.md) | quando algo falha |
+
+---
+
+## Os 5 minutos que resolvem 90% dos casos
+
+Você tem um Mac com Apple Silicon e quer rodar um modelo local com Ollama.
+
+**1. Decida a estratégia de pacote** (leia [o guia 2](02-visibilidade.md) — muda o
+que você faz agora e não dá para desfazer). Para a maioria, o caminho mais
+simples é um pacote compartilhado chamado `models`.
+
+**2. Rode o workflow** em *Actions → Sync HF Model to GHCR → Run workflow*:
+
+```
+model_repo   = bartowski/Qwen2.5-7B-Instruct-GGUF
+package_name = models
+```
+
+**3. Torne o pacote público, uma vez.** Perfil → aba **Packages** → `models` →
+**Package settings** → **Danger Zone** → **Change visibility** → **Public**.
+
+**4. Confirme** que ficou acessível sem credenciais:
+
+```bash
+python3 scripts/ghcr_ollama.py verify \
+  --repository <seu-usuário>/models --tag qwen2.5-7b-instruct-gguf-q4_k_m
+```
+
+**5. Baixe e rode:**
+
+```bash
+ollama pull ghcr.io/<seu-usuário>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+ollama run  ghcr.io/<seu-usuário>/models:qwen2.5-7b-instruct-gguf-q4_k_m
+```
+
+A partir daqui, todo modelo novo publicado nesse pacote já nasce público — o
+passo 3 nunca mais se repete.
+
+---
+
+## O que este repositório publica
+
+Cada execução gera **duas referências** no GHCR, a partir do mesmo modelo:
+
+```
+ghcr.io/<owner>/<pacote>:<tag>       manifesto nativo do Ollama
+ghcr.io/<owner>/<pacote>:<tag>-hf    artefato OCI no layout do Hugging Face
+```
+
+A primeira só o Ollama entende. A segunda serve a todo o resto — LM Studio,
+MLX, llama.cpp, transformers, vLLM — porque é o diretório do Hugging Face
+reconstruído arquivo por arquivo.
+
+O espelhamento **não converte nada**: ele copia fielmente o formato que existe
+no Hugging Face. Por isso a escolha do repositório de origem decide quais
+clientes vão funcionar. Isso está detalhado em
+[Escolher o modelo certo](04-escolher-modelo.md).

--- a/scripts/ghcr_ollama.py
+++ b/scripts/ghcr_ollama.py
@@ -645,17 +645,32 @@ def cmd_verify(args) -> int:
         return 1
 
     manifest = resp.json()
-    media_type = manifest.get("mediaType")
-    if media_type != MANIFEST_MEDIA_TYPE:
-        log(f"❌ mediaType do manifesto é {media_type!r}, o Ollama espera {MANIFEST_MEDIA_TYPE!r}")
-        return 1
-
     entries = layers_of(manifest)
-    kinds = sorted({e.get("mediaType", "?") for e in entries})
-    log(f"✅ manifesto OK ({len(entries)} blobs): {', '.join(kinds)}")
+    is_ollama = any(
+        e.get("mediaType") == "application/vnd.ollama.image.model" for e in entries
+    )
+    titled = [
+        e for e in entries if (e.get("annotations") or {}).get("org.opencontainers.image.title")
+    ]
 
-    if not any(e.get("mediaType") == "application/vnd.ollama.image.model" for e in entries):
-        log("❌ nenhuma camada application/vnd.ollama.image.model — o Ollama não vai carregar")
+    if is_ollama:
+        media_type = manifest.get("mediaType")
+        if media_type != MANIFEST_MEDIA_TYPE:
+            log(
+                f"❌ mediaType do manifesto é {media_type!r}, "
+                f"o Ollama espera {MANIFEST_MEDIA_TYPE!r}"
+            )
+            return 1
+        kinds = sorted({e.get("mediaType", "?") for e in entries})
+        log(f"✅ manifesto Ollama OK ({len(entries)} blobs): {', '.join(kinds)}")
+    elif titled:
+        log(f"✅ artefato OCI público com {len(titled)} arquivos no layout do Hugging Face")
+    else:
+        log(
+            "❌ a tag é pública, mas não é nem um manifesto do Ollama (falta a camada "
+            "application/vnd.ollama.image.model) nem um snapshot HF (faltam os "
+            "annotations org.opencontainers.image.title)"
+        )
         return 1
 
     # Um Range de 1 byte por blob confirma o redirect para a CDN e a permissão de
@@ -669,7 +684,10 @@ def cmd_verify(args) -> int:
             log(f"❌ blob {digest} respondeu vazio")
             return 1
     log(f"✅ todos os {len(entries)} blobs acessíveis anonimamente")
-    log(f"👉 ollama pull {args.registry}/{args.repository}:{args.tag}")
+    if is_ollama:
+        log(f"👉 ollama pull {args.registry}/{args.repository}:{args.tag}")
+    else:
+        log(f"👉 oras pull {args.registry}/{args.repository}:{args.tag} -o ./modelo")
     return 0
 
 

--- a/scripts/ghcr_ollama.py
+++ b/scripts/ghcr_ollama.py
@@ -105,7 +105,11 @@ def request(
     try:
         resp = _opener.open(req, timeout=timeout)
     except urllib.error.HTTPError as exc:  # 4xx/5xx ainda carregam corpo útil
-        body = exc.read() if read_body else b""
+        # HTTPError também é um objeto de resposta, segurando o socket. Fechar
+        # explicitamente devolve a conexão em vez de deixá-la para o GC — e
+        # drenar o corpo é o que permite reaproveitá-la.
+        with exc:
+            body = exc.read() if read_body else b""
         return Response(exc.code, exc.headers, body, url)
     with resp:
         body = resp.read() if read_body else b""
@@ -433,6 +437,41 @@ def blob_path(models_dir: str, digest: str) -> str:
     return os.path.join(models_dir, "blobs", digest.replace(":", "-"))
 
 
+def safe_join(dest_root: str, name: str) -> str:
+    """Resolve `name` dentro de `dest_root`, recusando qualquer tentativa de fuga.
+
+    O nome vem do annotation `org.opencontainers.image.title` de um artefato do
+    registro, ou seja: entrada não confiável. A validação é feita sobre os
+    componentes do caminho em vez de sobre a string final, porque comparar
+    prefixos depois de `normpath` é lexical — passa por links simbólicos, e
+    ignora `\\` como separador fora do Windows.
+    """
+    if not name or "\x00" in name:
+        raise SystemExit(f"nome de arquivo inválido no artefato: {name!r}")
+    if any(ord(c) < 32 for c in name):
+        raise SystemExit(f"caractere de controle no nome do artefato: {name!r}")
+    # `\` é separador no Windows e caractere comum no Linux: tratar como
+    # separador nos dois casos é o lado seguro do erro.
+    parts = [p for p in re.split(r"[\\/]+", name) if p not in ("", ".")]
+    if not parts:
+        raise SystemExit(f"nome de arquivo vazio no artefato: {name!r}")
+    if any(p == ".." for p in parts):
+        raise SystemExit(f"caminho suspeito no artefato: {name!r}")
+    if os.path.isabs(name) or re.match(r"^[A-Za-z]:", name):
+        raise SystemExit(f"caminho absoluto no artefato: {name!r}")
+    return os.path.join(dest_root, *parts)
+
+
+def assert_inside(dest_root: str, path: str) -> None:
+    """Confere, já com links simbólicos resolvidos, que `path` está sob `dest_root`."""
+    root = os.path.realpath(dest_root)
+    real = os.path.realpath(path)
+    if real != root and not real.startswith(root + os.sep):
+        raise SystemExit(
+            f"o caminho {path!r} escapa do destino via link simbólico (resolve para {real!r})"
+        )
+
+
 def read_local_manifest(models_dir: str, host: str, namespace: str, model: str, tag: str) -> tuple[dict, bytes]:
     path = os.path.join(models_dir, "manifests", host, namespace, model, tag)
     if not os.path.isfile(path):
@@ -580,33 +619,52 @@ def cmd_pull(args) -> int:
 
     for layer in titled:
         name = layer["annotations"]["org.opencontainers.image.title"]
-        # O título vem do registro: um `../` ali não pode escrever fora do destino.
-        target = os.path.normpath(os.path.join(dest_root, name))
-        if not target.startswith(dest_root + os.sep):
-            raise SystemExit(f"caminho suspeito no artefato: {name!r}")
-
+        target = safe_join(dest_root, name)
         size = int(layer["size"])
-        if os.path.isfile(target) and os.path.getsize(target) == size:
-            log(f"   • {name} já baixado")
-            continue
+
+        try:
+            if os.path.getsize(target) == size:
+                log(f"   • {name} já baixado")
+                continue
+        except OSError:
+            # Não existe, ou sumiu entre a verificação e o uso: baixa de novo.
+            pass
 
         os.makedirs(os.path.dirname(target), exist_ok=True)
+        # Só depois de criar os diretórios dá para resolver os links simbólicos:
+        # um `sub/` pré-existente apontando para fora escaparia da checagem
+        # lexical, que não enxerga links.
+        assert_inside(dest_root, os.path.dirname(target))
+
         log(f"   ↓ {name} ({human(size)})")
         digest = layer["digest"]
         hasher = hashlib.sha256()
-        stream = reg.open_blob(digest)
-        with stream, open(target + ".part", "wb") as out:
-            while True:
-                chunk = stream.read(4 * 1024 * 1024)
-                if not chunk:
-                    break
-                hasher.update(chunk)
-                out.write(chunk)
-        got = f"sha256:{hasher.hexdigest()}"
-        if got != digest:
-            os.remove(target + ".part")
-            raise SystemExit(f"digest divergente em {name}: esperado {digest}, obtido {got}")
-        os.replace(target + ".part", target)
+        partial = target + ".part"
+        try:
+            # O_NOFOLLOW fecha a última brecha: o próprio arquivo de destino não
+            # pode ser um link simbólico plantado antes.
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(partial, flags, 0o644)
+            with reg.open_blob(digest) as stream, os.fdopen(fd, "wb") as out:
+                while True:
+                    chunk = stream.read(4 * 1024 * 1024)
+                    if not chunk:
+                        break
+                    hasher.update(chunk)
+                    out.write(chunk)
+            got = f"sha256:{hasher.hexdigest()}"
+            if got != digest:
+                raise SystemExit(f"digest divergente em {name}: esperado {digest}, obtido {got}")
+            os.replace(partial, target)
+        except BaseException:
+            # Qualquer falha — rede, digest, Ctrl-C — não deixa lixo para trás.
+            # Sem isto, cada tentativa frustrada abandona um .part de vários GB
+            # que nenhuma execução seguinte remove.
+            try:
+                os.remove(partial)
+            except OSError:
+                pass
+            raise
 
     log(f"✅ pronto: {os.path.abspath(args.dest)}")
     return 0

--- a/scripts/hf_resolve.py
+++ b/scripts/hf_resolve.py
@@ -109,6 +109,35 @@ def list_files(repo: str, revision: str, token: str) -> list[dict]:
     return files
 
 
+def validate_paths(files: list[dict]) -> None:
+    """Recusa caminhos que quebrariam as etapas seguintes.
+
+    Os caminhos vêm da API do Hugging Face e atravessam duas ferramentas
+    sensíveis a caracteres especiais: o `oras push`, que recebe cada arquivo
+    como `caminho:media-type` na linha de comando, e o `snapshot_download`, que
+    os trata como padrões glob. Barrar aqui dá uma mensagem clara antes de
+    baixar nada, em vez de um erro obscuro 40 GB depois.
+    """
+    for entry in files:
+        path = entry["path"]
+        problema = None
+        if any(ord(c) < 32 for c in path):
+            problema = "contém caractere de controle"
+        elif path.startswith("-"):
+            problema = "começa com '-' e seria lido como flag pelo oras"
+        elif path.startswith("/") or re.match(r"^[A-Za-z]:", path):
+            problema = "é um caminho absoluto"
+        elif any(part == ".." for part in re.split(r"[\\/]+", path)):
+            problema = "contém '..'"
+        elif any(c in path for c in "*?[]"):
+            problema = "contém metacaractere de glob, que confundiria o download"
+        if problema:
+            raise SystemExit(
+                f"caminho inseguro no repositório: {path!r} — {problema}. "
+                "Use o input `exclude` para ignorá-lo."
+            )
+
+
 def matches(path: str, pattern: str) -> bool:
     return fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(os.path.basename(path), pattern)
 
@@ -287,6 +316,7 @@ def main() -> int:
 
     excludes = list(DEFAULT_EXCLUDES) + [p.strip() for p in args.exclude.split(",") if p.strip()]
     files = [f for f in files if not excluded(f["path"], excludes)]
+    validate_paths(files)
 
     gguf_group, alternatives = choose_gguf(files, args.file_pattern)
     projectors = [f for f in files if f["path"].lower().endswith(".gguf") and is_projector(f["path"])]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Regressão do tratamento de caminhos vindos de fontes não confiáveis.
+
+Dois pontos de entrada recebem strings que este repositório não controla:
+
+  * `org.opencontainers.image.title`, gravado por quem publicou o artefato no
+    registro, e usado para decidir onde escrever no disco de quem baixa.
+  * os caminhos de arquivo devolvidos pela API do Hugging Face, que viram
+    argumentos do `oras push` e padrões do `snapshot_download`.
+
+Rode com: python3 tests/test_paths.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+import tempfile
+
+RAIZ = pathlib.Path(__file__).resolve().parent.parent
+
+
+def carregar(nome: str):
+    caminho = RAIZ / "scripts" / f"{nome}.py"
+    spec = importlib.util.spec_from_file_location(nome, caminho)
+    modulo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+ghcr = carregar("ghcr_ollama")
+hf = carregar("hf_resolve")
+
+falhas: list[str] = []
+
+
+def checar(condicao: bool, descricao: str) -> None:
+    if condicao:
+        print(f"  ok   {descricao}")
+    else:
+        falhas.append(descricao)
+        print(f"  FALHA {descricao}")
+
+
+def rejeita(fn, *args) -> bool:
+    try:
+        fn(*args)
+    except SystemExit:
+        return True
+    return False
+
+
+def test_safe_join_rejeita_fuga():
+    print("safe_join recusa nomes que escapam do destino")
+    raiz = os.path.abspath(tempfile.mkdtemp())
+    hostis = [
+        "../fuga.txt",
+        "../../etc/passwd",
+        "a/../../x",
+        "a/b/../../../fora",
+        "/etc/passwd",
+        "C:\\x",
+        "..\\win.txt",
+        "a\\..\\..\\win",
+        "..",
+        ".",
+        "",
+        "x\x00y",
+        "linha\nquebrada",
+    ]
+    for nome in hostis:
+        checar(rejeita(ghcr.safe_join, raiz, nome), f"rejeita {nome!r}")
+
+
+def test_safe_join_aceita_legitimos():
+    print("safe_join aceita nomes normais e os mantém dentro do destino")
+    raiz = os.path.abspath(tempfile.mkdtemp())
+    for nome in [
+        "config.json",
+        "sub/ok.json",
+        "a/./b",
+        "dir/sub/model-00001-of-00002.safetensors",
+        "....//x",  # `....` é um diretório legítimo, não uma travessia
+    ]:
+        alvo = ghcr.safe_join(raiz, nome)
+        checar(alvo.startswith(raiz + os.sep), f"aceita e contém {nome!r}")
+
+
+def test_assert_inside_bloqueia_symlink():
+    print("assert_inside bloqueia fuga por link simbólico")
+    destino = tempfile.mkdtemp()
+    raiz = os.path.abspath(destino)
+    vitima = tempfile.mkdtemp()
+    os.symlink(vitima, os.path.join(destino, "link"))
+
+    # Lexicalmente o nome é impecável — é a resolução do link que denuncia.
+    alvo = ghcr.safe_join(raiz, "link/escapou.txt")
+    checar(alvo.startswith(raiz + os.sep), "safe_join sozinho não enxerga o link")
+    checar(
+        rejeita(ghcr.assert_inside, raiz, os.path.dirname(alvo)),
+        "assert_inside detecta o link que aponta para fora",
+    )
+    checar(
+        not rejeita(ghcr.assert_inside, raiz, raiz),
+        "assert_inside aceita o próprio destino",
+    )
+
+
+def test_part_nao_segue_symlink():
+    print("o arquivo .part não segue link simbólico plantado")
+    if not hasattr(os, "O_NOFOLLOW"):
+        print("  pulado (plataforma sem O_NOFOLLOW)")
+        return
+    destino = tempfile.mkdtemp()
+    vitima = os.path.join(tempfile.mkdtemp(), "alvo.txt")
+    parcial = os.path.join(destino, "arq.part")
+    os.symlink(vitima, parcial)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    try:
+        os.close(os.open(parcial, flags, 0o644))
+        seguiu = True
+    except OSError:
+        seguiu = False
+    checar(not seguiu, "O_NOFOLLOW recusa abrir o link")
+    checar(not os.path.exists(vitima), "o arquivo fora do destino não foi criado")
+
+
+def test_validate_paths():
+    print("validate_paths barra caminhos que quebrariam oras/download")
+    hostis = [
+        "-rf.gguf",
+        "linha\nquebrada.json",
+        "/etc/passwd",
+        "../x.gguf",
+        "m[1].safetensors",
+    ]
+    for caminho in hostis:
+        checar(
+            rejeita(hf.validate_paths, [{"path": caminho, "size": 1}]),
+            f"rejeita {caminho!r}",
+        )
+    legitimos = [
+        "config.json",
+        "model-00001-of-00002.safetensors",
+        "sub/dir/tokenizer.model",
+        "Qwen2.5-7B-Instruct-Q4_K_M.gguf",
+        "mmproj-model-f16.gguf",
+    ]
+    checar(
+        not rejeita(hf.validate_paths, [{"path": p, "size": 1} for p in legitimos]),
+        "aceita todos os caminhos legítimos",
+    )
+
+
+def test_request_nao_vaza_descritores():
+    print("request() não acumula descritores em respostas de erro")
+    if not os.path.isdir("/proc/self/fd"):
+        print("  pulado (sem /proc)")
+        return
+    import http.server
+    import threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            corpo = b'{"errors":[{"code":"NOT_FOUND"}]}'
+            self.send_response(404)
+            self.send_header("Content-Length", str(len(corpo)))
+            self.end_headers()
+            self.wfile.write(corpo)
+
+    servidor = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=servidor.serve_forever, daemon=True).start()
+    url = f"http://127.0.0.1:{servidor.server_address[1]}/x"
+
+    contar = lambda: len(os.listdir("/proc/self/fd"))
+    for _ in range(5):
+        ghcr.request("GET", url)
+    antes = contar()
+    for _ in range(60):
+        ghcr.request("GET", url)
+    depois = contar()
+    servidor.shutdown()
+    checar(depois <= antes, f"descritores estáveis em 60 erros ({antes} → {depois})")
+
+
+def main() -> int:
+    for teste in (
+        test_safe_join_rejeita_fuga,
+        test_safe_join_aceita_legitimos,
+        test_assert_inside_bloqueia_symlink,
+        test_part_nao_segue_symlink,
+        test_validate_paths,
+        test_request_nao_vaza_descritores,
+    ):
+        teste()
+        print()
+
+    if falhas:
+        print(f"❌ {len(falhas)} falha(s):")
+        for f in falhas:
+            print(f"   - {f}")
+        return 1
+    print("✅ todos os testes passaram")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Revisão dos 8 apontamentos de segurança feitos no #3, que foi mergeado antes da revisão. **Quatro se sustentam, quatro não.** Cada veredicto abaixo foi verificado contra o código e, quando possível, medido — não julgado por leitura.

Traz também a documentação em `docs/` que ficou fora do #3.

## Veredictos

### ✅ Procedem

**1. Path traversal — mas por um vetor diferente do apontado.** A checagem anterior (`normpath` + comparação de prefixo) bloqueia *todos* os `../` clássicos; testei 13 variações, incluindo caminho absoluto, `a/b/../../../fora` e confusão de prefixo, e nenhuma passa. O problema real é que a checagem é **lexical**: não enxerga links simbólicos. Com um `sub/` pré-existente no destino apontando para fora, o nome `sub/x` passava e a escrita saía:

```
alvo lexical : /tmp/destino/link/escapou.txt
alvo real    : /tmp/vitima/escapou.txt        ← fora do destino
```

Correção: validação por componente do caminho (tratando `\` como separador também fora do Windows, e recusando NUL e caracteres de controle), `realpath` no diretório-pai depois de criado, e `O_NOFOLLOW` no `.part`.

**2. Arquivos `.part` órfãos.** Não é vazamento de descritor — o `with` fecha os dois objetos, inclusive se o segundo `open()` falhar. Mas só o erro de digest limpava o parcial: qualquer falha de rede abandonava um arquivo de vários GB que nenhuma execução seguinte removia, porque a retomada testa o nome final. A limpeza passa a cobrir toda exceção, inclusive `KeyboardInterrupt`.

**3. TOCTOU em `isfile`/`getsize`.** Real, e trivial: o arquivo sumindo entre as duas chamadas derrubava o comando com traceback. Vira um `getsize` protegido.

**4. `HTTPError` não fechado.** Objetos de erro do `urllib` são respostas e seguram o socket. **Não consegui reproduzir acúmulo** — o teste novo mede 60 respostas de erro e o número de descritores fica estável (refcounting do CPython finaliza), então "resource exhaustion" é exagero. Mas fechar explicitamente é o certo, e devolve a conexão em vez de deixá-la para o GC.

### ❌ Não procedem

**5. "Missing failure check for `ollama serve`".** O `curl -sf` depois do laço *já* barra o passo: o shell padrão do Actions roda com `set -e` ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)). O que era ruim é o diagnóstico — 60 s de espera e um curl mudo. Agora o log do `serve` é capturado e o processo é checado a cada iteração, então uma queda na largada aparece na hora, com a mensagem.

**6. "Token exposure in process listings".** `--password-stdin` é exatamente a mitigação disso: o token nunca entra no argv. A alegação está errada. Existe um ponto menor e real — o bash materializa a here-string (`<<<`) num arquivo temporário. Troquei por `printf | oras login`, que evita até isso.

**7. "Command injection".** Não há injeção: `mapfile` popula um array e `"${FILES[@]}"` é expandido com aspas, sem avaliação pelo shell. Verifiquei também a preocupação implícita com `:` no nome do arquivo — o `oras` usa `strings.LastIndex(reference, ":")`, e o último `:` é sempre o que eu acrescento, então caminhos com `:` funcionam. O que existe são fragilidades a caracteres especiais, corrigidas na origem (ver abaixo) e com `mapfile -d ''`.

**8. "Arithmetic overflow".** A aritmética do bash é de 64 bits; tamanhos de disco não chegam perto de 2⁶³. O problema real é outro e mais sério: sem `pipefail`, um `df` que falha vira string vazia, que a aritmética lê como **zero**. Corrigido com `set -euo pipefail` e validação numérica explícita.

## Endurecimento adicional

Caminhos vindos do Hugging Face passam a ser validados no job `plan`, **antes de qualquer download**: nada de caractere de controle, `-` inicial (que o `oras` leria como flag), caminho absoluto, `..` ou metacaractere de glob (que o `snapshot_download` interpretaria como padrão). Uma barreira só, na entrada, protege as duas ferramentas a jusante.

## Testes

`tests/test_paths.py` cobre a regressão dos casos acima — 13 nomes hostis, 5 legítimos, a fuga por symlink, o `O_NOFOLLOW` e a medição de descritores. Simulei também em bash os dois trechos corrigidos do workflow (`df` falhando, servidor que morre na largada, servidor que nunca responde): os três falham com mensagem clara.

O novo `tests.yml` roda isso no CI e ainda passa `bash -n` em todos os blocos `run:` de todos os workflows — um erro de sintaxe ali só apareceria no meio de uma publicação de 40 GB. (Encontrei um assim enquanto escrevia este PR: uma crase dentro de aspas duplas que teria virado substituição de comando.)

O e2e contra o registro OCI de mentira continua passando nos 8 cenários.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuDgqGC3EhWinguUMDgths

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuDgqGC3EhWinguUMDgths)_